### PR TITLE
:warning: Switch to net-api from tar1090s json URL.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,11 @@
 [![Bandit](https://github.com/jquagga/upa/actions/workflows/bandit.yml/badge.svg)](https://github.com/jquagga/upa/actions/workflows/bandit.yml)
 [![Docker](https://github.com/jquagga/upa/actions/workflows/docker-publish.yml/badge.svg)](https://github.com/jquagga/upa/actions/workflows/docker-publish.yml)
 
-
 μPlaneAlert is small python file which polls a tar1090 instance to report on interesting planes seen by a SDR. This is a subset of the functionality provided by [docker-planefence](https://github.com/sdr-enthusiasts/docker-planefence) written by Ramon F. Kolb. It's intended to run entirely in RAM and sleep between 90 second runs. It's one file, one process. Less functionally but easier on systems with less resources.
 
 ## Installation
 
-Traditionally you would run upa in the docker-compose.yml stack along with ultrafeeder. It's default configuration is set to directly access the ultrafeeder container and read aircraft data, however that is configurable and it can run anywhere that has access to the aircraft.json file.
+Traditionally you would run upa in the docker-compose.yml stack along with ultrafeeder. It's default configuration is set to directly access the ultrafeeder container and read aircraft data, however that is configurable and it can run anywhere that has access to the either aircraft.json file (commonly from tar1090) or the net-api port of readsb (accessable if you have direct access to the ultrafeeder or readsb container **even if you aren't running tar1090**).
 
 ```yaml
 services:

--- a/upa.py
+++ b/upa.py
@@ -127,7 +127,7 @@ def notify(plane):
 def main():
     build_database()
     print("Sleeping 60 seconds for ultrafeeder start-up")
-    json_url = os.environ.get("UPA_JSON_URL", "http://ultrafeeder/data/aircraft.json")
+    json_url = os.environ.get("UPA_JSON_URL", "http://ultrafeeder:30152/?all_with_pos")
     time.sleep(60)
     while 1:
         start_time = time.perf_counter()


### PR DESCRIPTION
If you run upa in a docker network with ultrafeeder, you won't even notice.  If you manually set the UPA_JSON_URL you also won't notice!

This change does mean that tar1090 is no longer required for upa; it can get it's data right from ultrafeeder or ureadsb.